### PR TITLE
Fixed the bug when the user displayed the keyboard

### DIFF
--- a/lib/screens/expenditure_detail.dart
+++ b/lib/screens/expenditure_detail.dart
@@ -16,7 +16,7 @@ class ExpenditureScreen extends StatelessWidget {
 	Widget build(BuildContext context) {
 		final Expenditure expenditure = ModalRoute.of(context)!.settings.arguments as Expenditure;
 		return Scaffold(
-
+      resizeToAvoidBottomInset: false,
 			body: Stack(
 			  children:[
 			    const Background(),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -11,6 +11,7 @@ class LoginScreen extends StatelessWidget {
 	@override
 	Widget build(BuildContext context) {
 		return const Scaffold(
+      resizeToAvoidBottomInset: false,
 			body: Stack(
 				children:[
 					Background(),

--- a/lib/screens/pending_payments.dart
+++ b/lib/screens/pending_payments.dart
@@ -55,6 +55,7 @@ class DebtsScreen extends StatelessWidget {
 		return  Scaffold(
 			appBar: AppBar(title: const Text("Pagos Pendientes", style: TextStyle(color: Colors.white)),),
 			drawer: const Drawer(child: MyDrawer()),
+			resizeToAvoidBottomInset: false,
 			body: Center(
 				 child: Stack(
 						children: [

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -12,6 +12,7 @@ class RegisterScreen extends StatelessWidget {
 	@override
 	Widget build(BuildContext context) {
 		return const Scaffold(
+      resizeToAvoidBottomInset: false,
 			body: Stack(
 				children:[
 					Background(),

--- a/lib/screens/spends_objetives_screen.dart
+++ b/lib/screens/spends_objetives_screen.dart
@@ -30,6 +30,7 @@ class _SpendObjetivesScreenState extends State<SpendObjetivesScreen> {
 									]),
 						),
 						drawer:  const Drawer(child: MyDrawer()),
+						resizeToAvoidBottomInset: false,
 						body:  const TabBarView(
 								children: [
 									ExpensesList(),


### PR DESCRIPTION
### **Trello task**

https://trello.com/c/5TWUn3Ur/29-exception-caused-when-displaying-keyboard-in-add-pending-payments

### **Summary:** 

Fixed the bug when the user displayed the keyboard, there was an overflow of 50 pixels when the scaffold resized
the fix consist of this line of code in Scaffold widget: "resizeToAvoidBottomInset: false"

### Results:

![image](https://github.com/RafaelSerranoGamarraProyects/MessUpp/assets/58252921/bddf7349-a139-4df0-93a9-407f268e904a)


#### Clean Code
- There is neither debug code nor lines that are commented out.
- There are no files unnecessarily modified *(all modifications are strictly related to the PR purpose).*

#### Testing


# It's our duty to keep quality!
