### PR TITLE
Add group expense, screens, form, salary, models

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,6 @@ class AppState extends StatelessWidget {
 }
 
 class MyApp extends StatelessWidget {
-  
   const MyApp({super.key});
   
   @override

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,3 +1,4 @@
+export 'package:Messup/models/transaction_beneficiary.dart';
 export 'package:Messup/models/calculated_debt.dart';
 export 'package:Messup/models/salary_algorithm.dart';
 export 'package:Messup/models/monetary_transaction.dart';

--- a/lib/models/transaction_beneficiary.dart
+++ b/lib/models/transaction_beneficiary.dart
@@ -1,0 +1,10 @@
+class TransactionBeneficiary {
+  final String name;
+  bool isBeneficiary;
+
+  TransactionBeneficiary({required this.name, required this.isBeneficiary});
+}
+
+List<TransactionBeneficiary> mapStringsToBeneficiaries(List<String> strings) {
+  return strings.map((string) => TransactionBeneficiary(name: string, isBeneficiary: false)).toList();
+}

--- a/lib/providers/add_group_expense.dart
+++ b/lib/providers/add_group_expense.dart
@@ -1,0 +1,61 @@
+import 'package:Messup/models/monetary_transaction.dart';
+import 'package:Messup/models/transaction_beneficiary.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+
+class CreateGroupExpenseProvider extends ChangeNotifier {
+
+  GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
+	double _amount = 0;
+	double get amount => _amount;
+
+	String _name = "";
+  String get name => _name;
+
+	String _payer = "";
+  String get payer => _payer;
+
+	List<String> _beneficiaries = [];
+  List<String> get beneficiaries => _beneficiaries;
+  
+  set name( String value){
+    _name = value;
+    notifyListeners();
+  }
+
+	set beneficiaries(List<String> value) {
+		_beneficiaries = value;
+		notifyListeners();
+	}
+
+	set amount(double value) {
+		_amount = value;
+		notifyListeners();
+	}
+
+	set payer(String value) {
+		_payer = value;
+		notifyListeners();
+	}
+
+  bool isValidForm() {
+		final validFields = (payer != "" && amount != 0 && name != "" && beneficiaries.isEmpty == false);
+    return validFields;
+  }
+
+  MonetaryTransaction createTransaction() {
+		return  MonetaryTransaction(name: name, payer: payer, beneficiaries: beneficiaries, amount: amount);
+	}
+
+  void updateBeneficiaries(TransactionBeneficiary participant) {
+		if (beneficiaries.contains(participant.name) && participant.isBeneficiary == false) {
+			beneficiaries.remove(participant.name);
+		}
+		if(!beneficiaries.contains(participant.name) && participant.isBeneficiary == true) {
+			beneficiaries.add(participant.name);
+		}
+
+	}
+}

--- a/lib/providers/groups_provider.dart
+++ b/lib/providers/groups_provider.dart
@@ -80,9 +80,20 @@ class GroupsProvider extends ChangeNotifier {
     }
   }
 
+  void updateTransactions(Group group) async {
+    for (Group currentGroup in userGroups) {
+      if (currentGroup.id == group.id) {
+        currentGroup.transactions = group.transactions;
+        final Map<String,dynamic> body = currentGroup.toJson();
+        await groupsCollection.doc(group.id).set(body);   
+        notifyListeners();
+        break;
+      }
+    }
+  }
+
   void deleteGroup(Group group) async {
     await groupsCollection.doc(group.id).delete();
     notifyListeners();
   }
-
 }

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -1,3 +1,4 @@
+export 'package:Messup/providers/add_group_expense.dart';
 export 'package:Messup/providers/create_group.dart';
 export 'package:Messup/providers/add_group_payment_form.dart';
 export 'package:Messup/providers/add_pending_payment_form.dart';

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -22,9 +22,12 @@ class AppRoutes {
     RouteOption(
         route: 'group_details',
         screen: const GroupDetailsScreen()),
-            RouteOption(
+    RouteOption(
         route: 'create_group',
         screen: const GroupCreation()),
+    RouteOption(
+        route: 'add_group_expense',
+        screen: const AddGroupExpense()),
 	RouteOption(
         route: 'expenditureDetail',
         screen: const ExpenditureScreen()),

--- a/lib/screens/create_group_expense.dart
+++ b/lib/screens/create_group_expense.dart
@@ -1,0 +1,175 @@
+import 'package:Messup/models/group.dart';
+import 'package:Messup/widgets/group_beneficiaries_section.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/providers.dart';
+import '../theme/custom_styles.dart';
+import '../widgets/widgets.dart';
+
+class AddGroupExpense extends StatelessWidget {
+  const AddGroupExpense({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final Group group = ModalRoute.of(context)!.settings.arguments as Group;
+		return Scaffold(
+			appBar: AppBar(title: Row(
+			  children: [
+					ReturnToButton(route: "group_details", arguments: group),
+			    const Text("Añadir gasto", style: TextStyle(color: Colors.white), overflow: TextOverflow.ellipsis,),
+			  ],
+			)),
+			resizeToAvoidBottomInset: false,
+      body:  const Stack(
+        children: [
+          Background(),
+					_AddGroupExpenseForm(),
+        ],
+      ),
+    );
+  }
+}
+
+class _AddGroupExpenseForm extends StatelessWidget {
+  const _AddGroupExpenseForm({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final Group group = ModalRoute.of(context)!.settings.arguments as Group;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        ChangeNotifierProvider(
+          create: (_) => CreateGroupExpenseProvider(),
+          child: _CreateGroupExpenseFormBody(group: group),
+        ),
+      ],
+    );
+  }
+}
+
+class _CreateGroupExpenseFormBody extends StatelessWidget {
+  const _CreateGroupExpenseFormBody({
+    required this.group,
+  });
+
+  final Group group;
+
+  @override
+  Widget build(BuildContext context) {
+    final createGroupExpense = Provider.of<CreateGroupExpenseProvider>(context);
+    return Form(
+      key: createGroupExpense.formKey,
+      child: Column(
+            children: [
+                const _ExpenseTitleSection(),
+              const _ExpenseAmountSection(),
+              _PayerSection(group: group),
+                const _BeneficiariesSection(),
+                const SummnitButton()
+            ]),
+    );
+  }
+}
+
+class _PayerSection extends StatelessWidget {
+  const _PayerSection({
+    required this.group,
+  });
+
+  final Group group;
+
+  @override
+  Widget build(BuildContext context) {
+    final createGroupExpenseProvider = Provider.of<CreateGroupExpenseProvider>(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: Text('Pagador', style: TextStyle(color: Colors.white, fontWeight: FontWeight.normal, fontSize: 20)),
+        ),
+        PayerDropdown(participants: group.participants, onPayerSelected: (p0) => createGroupExpenseProvider.payer = p0),
+      ],
+    );
+  }
+}
+
+class SummnitButton extends StatelessWidget {
+  const SummnitButton({ super.key });
+
+  @override
+  Widget build(BuildContext context) {
+		final createGroupExpenseProvider = Provider.of<CreateGroupExpenseProvider>(context);
+    final groupsProvider = Provider.of<GroupsProvider>(context);
+
+    final Group group = ModalRoute.of(context)!.settings.arguments as Group;
+		final size = MediaQuery.of(context).size;
+
+    return ElevatedButton(onPressed:() {
+      if (createGroupExpenseProvider.isValidForm()) {
+        group.transactions.add(createGroupExpenseProvider.createTransaction());
+        groupsProvider.updateTransactions(group);
+        Navigator.pushReplacementNamed(context, "group_details", arguments: group);
+      }
+    },
+     style: ElevatedButton.styleFrom(backgroundColor: AppTheme.primaryColor, minimumSize: Size(size.width - 40, 100)),
+     child: const Text("Añadir Gasto"),);
+  }
+}
+
+class _ExpenseTitleSection extends StatelessWidget {
+  const _ExpenseTitleSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+    Padding(
+        padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        child: Text('Titulo', style: TextStyle(color: Colors.white, fontWeight: FontWeight.normal, fontSize: 20)),
+      ),
+    AddGroupDebtName(),
+    ],);
+  }
+}
+
+class _ExpenseAmountSection extends StatelessWidget {
+  const _ExpenseAmountSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Padding(
+          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: Text('Cantidad a pagar', style: TextStyle(color: Colors.white, fontWeight: FontWeight.normal, fontSize: 20)),
+        ),  
+      AddGroupDebtAmount(),
+    ],);
+  }
+}
+
+class _BeneficiariesSection extends StatelessWidget {
+  const _BeneficiariesSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final Group group = ModalRoute.of(context)!.settings.arguments as Group;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+    	  const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: Text('Participantes', style: TextStyle(color: Colors.white, fontWeight: FontWeight.normal, fontSize: 20)),
+        ),
+        BeneficiariesList(group: group),
+    ],
+    );
+  }
+}
+
+

--- a/lib/screens/group_participants_screen.dart
+++ b/lib/screens/group_participants_screen.dart
@@ -16,7 +16,6 @@ class ParticipantsScreen extends StatelessWidget {
 	Widget build(BuildContext context) {
 		final Group group = ModalRoute.of(context)!.settings.arguments as Group;
 		final groupProvider = Provider.of<GroupsProvider>(context);
-		final size = MediaQuery.of(context).size;
 		return  Scaffold(
 			appBar: AppBar(title: Row(
 			  children: [

--- a/lib/screens/groups_expenditures.dart
+++ b/lib/screens/groups_expenditures.dart
@@ -1,85 +1,84 @@
+import 'package:Messup/widgets/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:Messup/theme/app_theme.dart';
-
 import '../models/models.dart';
+import '../theme/custom_styles.dart';
 import '../utils/utils.dart';
-import '../widgets/widgets.dart';
 
 class GroupExpenditures extends StatelessWidget {
   const GroupExpenditures({
-    super.key,
+    Key? key,
     required this.group,
-  });
+  }) : super(key: key);
 
   final Group group;
 
   @override
   Widget build(BuildContext context) {
     return Stack(
-				children:  [
-					const Background(),
-					SafeArea(
-						child: Column(
-							children:  [
-								 ExpendituresList(group: group)	
-							],
-						 ),
-					),
-				],
+      children: [
+        const Background(),
+        SafeArea(
+          child: Column(
+            children: [
+              Expanded(
+                child: ExpendituresList(group: group),
+              ),
+              Container(
+                padding: const EdgeInsets.only(bottom: 10, left: 10, right: 10),
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.pushReplacementNamed(context, "add_group_expense", arguments: group);
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppTheme.primaryColor,
+                  ),
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 16.0),
+                    child: Text(
+                      "Añadir gasto grupal",
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 18
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
 
 class ExpendituresList extends StatelessWidget {
   const ExpendituresList({
-    super.key,
+    Key? key,
     required this.group,
-  });
+  }) : super(key: key);
 
   final Group group;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-									padding: const EdgeInsets.only(top: 5),
-									alignment: Alignment.center,
-									height: 300,
-									child: ListView.builder(
-										itemCount: group.transactions.length,
-										itemBuilder: (_, index) {
-                      final monetaryTransaction = MonetaryTransaction(name: group.transactions[index].name,
-                        payer: group.transactions[index].payer,
-                        beneficiaries: Parser.parseFromListDynamicToListString(group.transactions[index].beneficiaries),
-                        amount: group.transactions[index].amount
-                      );
-                      return CustomTransactionItem(transaction: monetaryTransaction);
-                    }
-									),
+      padding: const EdgeInsets.only(top: 5),
+      alignment: Alignment.center,
+      child: ListView.builder(
+        itemCount: group.transactions.length,
+        itemBuilder: (_, index) {
+          final monetaryTransaction = MonetaryTransaction(
+            name: group.transactions[index].name,
+            payer: group.transactions[index].payer,
+            beneficiaries: Parser.parseFromListDynamicToListString(group.transactions[index].beneficiaries),
+            amount: group.transactions[index].amount,
+          );
+          return CustomTransactionItem(transaction: monetaryTransaction);
+        },
+      ),
     );
-  }
-}
-
-class CustomTransactionItem extends StatelessWidget {
-  const CustomTransactionItem({
-    super.key,
-    required this.transaction,
-  });
-
-  final MonetaryTransaction transaction;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-			padding: const EdgeInsets.symmetric(horizontal: 10.0),
-			child: Card(
-					color: Colors.white,
-					margin: const EdgeInsets.symmetric(vertical: 10),
-					child: ListTile(
-						title: Text(transaction.name, style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: Colors.black),),
-						subtitle: Text(" Pagado por: ${transaction.payer}", style: const TextStyle(fontSize: 16, fontWeight: FontWeight.normal, color: AppTheme.secondaryBlue),),
-						trailing: Text("${transaction.amount} €", style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.black,)),
-					),
-				),
-		);
   }
 }

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -1,3 +1,4 @@
+export 'package:Messup/screens/create_group_expense.dart';
 export 'package:Messup/screens/group_participants_screen.dart';
 export 'package:Messup/screens/groups_expenditures.dart';
 export 'package:Messup/screens/salary_screen.dart';

--- a/lib/theme/custom_validators.dart
+++ b/lib/theme/custom_validators.dart
@@ -23,10 +23,10 @@ class CustomValidators{
 		: 'Error. La contraseña debe tener al menos 8 caracteres y contener un Digito, Caracter Especial, Mayuscula.';
 	}
 
-	static String? groupNameNotEmpty({
+	static String? notEmptyField({
 		required dynamic value,
 	}) {
-		return (value != "" || value != null) ? null : 'Debe introducir un nombre de grupo';
+		return (value != "" || value != null) ? null : 'Debe introducir un valor';
 	}
 }  
 

--- a/lib/widgets/add_grout_debt.dart
+++ b/lib/widgets/add_grout_debt.dart
@@ -1,0 +1,91 @@
+// ignore_for_file: library_private_types_in_public_api
+
+import 'package:Messup/theme/custom_validators.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/models.dart';
+import '../providers/providers.dart';
+
+class AddGroupDebtName extends StatefulWidget {
+  const AddGroupDebtName({super.key});
+
+  @override
+  AddGroupDebtState createState() => AddGroupDebtState();
+}
+
+class AddGroupDebtState extends State<AddGroupDebtName> {
+  final TextEditingController _controller = TextEditingController();
+  List<String> participants = [];
+
+  @override
+  Widget build(BuildContext context) {
+		final createGroupExpense = Provider.of<CreateGroupExpenseProvider>(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 10),
+      child: Expanded(
+        child: TextFormField(
+          controller: _controller,
+          validator: (value) => CustomValidators.notEmptyField(value: value),
+          decoration: const InputDecoration(
+            labelText: 'Entrada del Cine',
+										fillColor: Colors.white, // Fondo blanco
+    								filled: true,
+    								labelStyle: TextStyle(color: Colors.black), // Color del texto de la etiqueta
+    								hintStyle: TextStyle(color: Colors.black),
+          ),
+					onChanged: (value) {
+						createGroupExpense.name = value;
+					},
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}
+
+class AddGroupDebtAmount extends StatefulWidget {
+  const AddGroupDebtAmount({Key? key}) : super(key: key);
+
+  @override
+  _AddGroupDebtAmountState createState() => _AddGroupDebtAmountState();
+}
+
+class _AddGroupDebtAmountState extends State<AddGroupDebtAmount> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final createGroupExpense = Provider.of<CreateGroupExpenseProvider>(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 10),
+      child: TextFormField(
+        controller: _controller,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true), // Acepta números decimales
+        validator: (value) => CustomValidators.notEmptyField(value: value.toString()),
+        decoration: const InputDecoration(
+          labelText: 'Monto',
+          fillColor: Colors.white,
+          filled: true,
+          labelStyle: TextStyle(color: Colors.black),
+          hintStyle: TextStyle(color: Colors.black),
+        ),
+        onChanged: (value) {
+          createGroupExpense.amount = double.tryParse(value) ?? 0.0;
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}
+

--- a/lib/widgets/beneficiary_row.dart
+++ b/lib/widgets/beneficiary_row.dart
@@ -1,0 +1,44 @@
+// ignore_for_file: library_private_types_in_public_api
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/models.dart';
+import 'package:Messup/theme/app_theme.dart';
+import '../providers/providers.dart';
+
+class ParticipantRow extends StatefulWidget {
+  final TransactionBeneficiary participant;
+
+  const ParticipantRow({Key? key, required this.participant}) : super(key: key);
+
+  @override
+  _ParticipantRowState createState() => _ParticipantRowState();
+}
+
+class _ParticipantRowState extends State<ParticipantRow> {
+  @override
+  Widget build(BuildContext context) {
+    final creationGroupExpenseProvider = Provider.of<CreateGroupExpenseProvider>(context);
+    return Card(
+      child: ListTile(
+        title: Text(
+          widget.participant.name,
+          style: const TextStyle(color: AppTheme.primaryColor, fontSize: 19),
+        ),
+        trailing: Checkbox(
+          checkColor: AppTheme.primaryColor,
+          fillColor: MaterialStateProperty.all(Colors.white),
+          value: widget.participant.isBeneficiary,
+          onChanged: (newValue) {
+            setState(() {
+              if (newValue != null) {
+                widget.participant.isBeneficiary = newValue;
+                creationGroupExpenseProvider.updateBeneficiaries(widget.participant);
+              }
+            });
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_transaction_item.dart
+++ b/lib/widgets/custom_transaction_item.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import '../models/models.dart';
+import '../theme/custom_styles.dart';
+
+class CustomTransactionItem extends StatelessWidget {
+  const CustomTransactionItem({
+    super.key,
+    required this.transaction,
+  });
+
+  final MonetaryTransaction transaction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+			padding: const EdgeInsets.symmetric(horizontal: 10.0),
+			child: Card(
+					color: Colors.white,
+					margin: const EdgeInsets.symmetric(vertical: 10),
+					child: ListTile(
+						title: Text(transaction.name, style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: Colors.black),),
+						subtitle: Text(" Pagado por: ${transaction.payer}", style: const TextStyle(fontSize: 16, fontWeight: FontWeight.normal, color: AppTheme.secondaryBlue),),
+						trailing: Text("${transaction.amount} €", style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.black,)),
+					),
+				),
+		);
+  }
+}

--- a/lib/widgets/group_beneficiaries_section.dart
+++ b/lib/widgets/group_beneficiaries_section.dart
@@ -1,0 +1,44 @@
+import 'package:Messup/models/models.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/providers.dart';
+import 'widgets.dart';
+
+class BeneficiariesList extends StatefulWidget {
+  final Group group;
+
+  const BeneficiariesList({Key? key, required this.group}) : super(key: key);
+
+  @override
+  BeneficiariesListState createState() => BeneficiariesListState();
+}
+
+class BeneficiariesListState extends State<BeneficiariesList> {
+  final TextEditingController _controller = TextEditingController();
+  late List<TransactionBeneficiary> participants;
+
+  @override
+  void initState() {
+    super.initState();
+		participants = mapStringsToBeneficiaries(widget.group.participants);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 280,
+      child: ListView.builder(
+        itemCount: participants.length,
+        itemBuilder: (context, index) {
+          return ParticipantRow(participant: participants[index]);
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/lib/widgets/payer_selection.dart
+++ b/lib/widgets/payer_selection.dart
@@ -1,0 +1,47 @@
+import 'package:Messup/theme/custom_styles.dart';
+import 'package:flutter/material.dart';
+
+class PayerDropdown extends StatefulWidget {
+  final List<String> participants;
+  final Function(String) onPayerSelected;
+
+  const PayerDropdown({Key? key, required this.participants, required this.onPayerSelected}) : super(key: key);
+
+  @override
+  // ignore: library_private_types_in_public_api
+  _PayerDropdownState createState() => _PayerDropdownState();
+}
+
+class _PayerDropdownState extends State<PayerDropdown> {
+  String? _selectedPayer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+      child: Container(
+        color: Colors.white,
+        child: DropdownButtonFormField<String>(
+          validator: (value) => CustomValidators.notEmptyField(value: value),
+          value: _selectedPayer,
+          items: widget.participants.map((participant) {
+            return DropdownMenuItem<String>(
+              value: participant,
+              child: Text(participant),
+            );
+          }).toList(),
+          onChanged: (selectedPayer) {
+            setState(() {
+              _selectedPayer = selectedPayer;
+            });
+            widget.onPayerSelected(selectedPayer!);
+          },
+          decoration: InputDecorations.dropDownMenuInputDecoration(labelText: 'Seleccione un pagador', icon: Icons.money),
+          onTap: () {
+            FocusScope.of(context).unfocus(); // Cierra el teclado si está abierto
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,3 +1,6 @@
+export 'package:Messup/widgets/payer_selection.dart';
+export 'package:Messup/widgets/beneficiary_row.dart';
+export 'package:Messup/widgets/add_grout_debt.dart';
 export 'package:Messup/widgets/participant_card.dart';
 export 'package:Messup/widgets/return_to_button.dart';
 export 'package:Messup/widgets/group_name_form.dart';
@@ -16,3 +19,4 @@ export 'package:Messup/widgets/list_category_cards.dart';
 export 'package:Messup/widgets/objetive_view.dart';
 export 'package:Messup/widgets/popup_form_add_objetive.dart';
 export 'package:Messup/widgets/popup_form_add.dart';
+export 'package:Messup/widgets/custom_transaction_item.dart';


### PR DESCRIPTION
### **Trello task**

https://trello.com/c/iT5rFGkN/8-create-salaryalgorithm-part-1
https://trello.com/c/sZM6btC2/24-create-salaryalgorithm-part-2
https://trello.com/c/xjEHFTj8/33-create-button-add-group-debt

### **Summary:** 

Added group expenditure and the screens associated

### Results:

<img width="379" alt="Captura de pantalla 2024-04-23 a las 15 30 45" src="https://github.com/RafaelSerranoGamarraProyects/MessUpp/assets/58252921/e91fc8d7-2cb0-4e87-b366-c0a9ba022f3a">

<img width="373" alt="Captura de pantalla 2024-04-23 a las 15 30 29" src="https://github.com/RafaelSerranoGamarraProyects/MessUpp/assets/58252921/d37d80ea-b638-4657-8478-8d70a8202128">

<img width="365" alt="Captura de pantalla 2024-04-23 a las 15 35 01" src="https://github.com/RafaelSerranoGamarraProyects/MessUpp/assets/58252921/138f9f13-bba9-4873-8d59-00d0c3447f5a">

#### Clean Code
- There is neither debug code nor lines that are commented out.
- There are no files unnecessarily modified *(all modifications are strictly related to the PR purpose).*

#### Testing


# It's our duty to keep quality!
